### PR TITLE
[RFC] streamer type generation

### DIFF
--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -1,13 +1,20 @@
 # A collection of bootstrapped code which should be generated
 # dynamically in future.
 
-abstract type TNamed <: ROOTStreamedObject end
-struct TNamed_1 <: TNamed end
-function readfields!(io, fields, ::Type{TNamed_1})
-    parsefields!(io, fields, TObject)
-    fields[:fName] = readtype(io, String)
-    fields[:fTitle] = readtype(io, String)
+# TODO: furthuer factoring this out, maybe parsing some ROOT headers
+function _generate_T_Types(name)
+    if startswith(string(name), "TName")
+        @eval function readfields!(io, fields, ::Type{$name})
+            parsefields!(io, fields, TObject)
+            fields[:fName] = readtype(io, String)
+            fields[:fTitle] = readtype(io, String)
+        end
+    end
 end
+
+
+# https://root.cern.ch/doc/master/TNamed_8h_source.html
+abstract type TNamed <: ROOTStreamedObject end
 
 abstract type TAttLine <: ROOTStreamedObject end
 struct TAttLine_1 <: TAttLine end

--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -55,7 +55,7 @@ function initialise_streamer(s::StreamerInfo)
     if !isdefined(@__MODULE__, name)
         @debug "  creating versioned struct '$name <: $supername'"
         @eval struct $(name) <: $(supername) end
-        # FIXME create the stream!() functions somewhere here...
+        _generate_T_Types(name)
         # println(name)
         # @eval struct $name <: ROOTStreamedObject
         #     data::Dict{Symbol, Any}


### PR DESCRIPTION
I think your original `TODO` had a typo? we are generating for `readfields!` it seems.

We come up with a structure so we don't need to type out an entire `@eval function ....` in the `_generate_T_Types`. This PR serves as a POC, and at least avoid hard-coding for each n in `TType_n` variation