### PR TITLE
Add .gitattributes to ignore some non-source code files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Notebook examples
+notebooks/* linguist-detectable=false
+
+# Scripts to generate data for tests
+test/samples/* linguist-detectable=false


### PR DESCRIPTION
With this pull request:

```console
% github-linguist --breakdown
100.00% Julia

Julia:
src/UnROOT.jl
src/bootstrap.jl
src/constants.jl
src/custom.jl
src/io.jl
src/root.jl
src/streamers.jl
src/types.jl
src/utils.jl
test/runtests.jl
```