### PR TITLE
Add cache after branch is interpreted

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -41,7 +41,7 @@ Reads an array from ith basket of a branch. Set `raw=true` to return raw data an
 """
 basketarray(f::ROOTFile, path::AbstractString, ithbasket) = basketarray(f, f[path], ithbasket)
 
-function basketarray(f::ROOTFile, branch, ithbasket)
+@memoize LRU(; maxsize=1 * 1024^3, by=x->sum(length, x)) function basketarray(f::ROOTFile, branch, ithbasket)
     ismissing(branch) && error("No branch found at $path")
     length(branch.fLeaves.elements) > 1 && error(
             "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.")

--- a/src/root.jl
+++ b/src/root.jl
@@ -133,7 +133,6 @@ function Base.getindex(t::T, s::AbstractString) where {T<:Union{TTree, TBranchEl
     end
     @debug "Searching for branch '$s' in $(length(t.fBranches.elements)) branches."
     for branch in t.fBranches.elements
-        @debug branch.fName
         if branch.fName == s
             return branch
         end
@@ -253,6 +252,13 @@ readbasket(f::ROOTFile, branch, ith) = readbasketseek(f, branch, branch.fBasketS
     unlock(f)
 
     basketrawbytes = decompress_datastreambytes(compressedbytes, basketkey)
+
+    @debug begin
+        ibasket = findfirst(==(seek_pos), branch.fBasketSeek)
+        mbcompressed = length(compressedbytes)/1024^2
+        mbuncompressed = length(basketrawbytes)/1024^2
+        "Read branch $(branch.fName), basket $(ibasket), $(mbcompressed) MB compressed, $(mbuncompressed) MB uncompressed"
+    end
 
     Keylen = basketkey.fKeylen
     contentsize = Int32(basketkey.fLast - Keylen)


### PR DESCRIPTION
There's currently a 3GB cache for raw unpacked basket data. Adding a 1GB cache after branch interpretation can help a lot for non-trivial branches especially when playing/exploring interactively on a small set of branches. E.g.,

```julia
julia> length(t)
962975

julia> t.Electron_pt[1:5]
5-element Vector{Vector{Float32}}:
 []
 [18.828014]
 [31.292875, 25.108507]
 [106.96358, 19.502377, 16.525389]
 [21.751484, 13.741731]
```
before (without 1GB cache)
```julia
julia> @time length.(t.Electron_pt);
  1.000231 seconds (4.82 M allocations: 324.212 MiB, 3.58% gc time)
```
after (with  1GB cache)
```julia
julia> @time length.(t.Electron_pt);
  0.138824 seconds (3.48 k allocations: 8.036 MiB)
```