### PR TITLE
Thread-safety & locking

### DIFF
--- a/src/displays.jl
+++ b/src/displays.jl
@@ -1,11 +1,7 @@
 function children(f::ROOTFile)
     ch = Vector{TTree}()
     for k in keys(f)
-        try
-            push!(ch, f[k])
-        catch
-            unlock(f) #TODO remove these hacks
-        end
+        push!(ch, f[k])
     end
     ch
 end

--- a/src/root.jl
+++ b/src/root.jl
@@ -112,10 +112,10 @@ end
     lock(f)
     try
         S = streamer(f.fobj, tkey, f.streamers.refs)
+        return S
     finally
         unlock(f)
     end
-    S
 end
 
 function Base.keys(f::ROOTFile)

--- a/src/root.jl
+++ b/src/root.jl
@@ -110,8 +110,11 @@ end
     @debug "Retrieving $s ('$(tkey.fClassName)')"
     streamer = getfield(@__MODULE__, Symbol(tkey.fClassName))
     lock(f)
-    S = streamer(f.fobj, tkey, f.streamers.refs)
-    unlock(f)
+    try
+        S = streamer(f.fobj, tkey, f.streamers.refs)
+    finally
+        unlock(f)
+    end
     S
 end
 


### PR DESCRIPTION
I propose to introduce the [exemplary](https://github.com/JuliaLang/julia/blob/master/base/lock.jl#L20-L25) usage of the `lock` at least in `_getindex()`. The reading of the baskets itself in  `readbasketseek()` is very low level and straightforward, so I guess the risk of something going wrong there is not too high.