### PR TITLE
Improvde LazyBranch cache hitting path speed by x10

### DIFF
--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -370,6 +370,11 @@ end
 
 abstract type TBranch <: ROOTStreamedObject end
 abstract type TBranchElement <: ROOTStreamedObject end
+function Base.hash(b::Union{TBranch, TBranchElement}, h::UInt)
+    h = hash(b.fFileName, h)
+    h = hash(b.fName, h)
+    h = hash(b.fEntries, h)
+end
 Base.length(b::Union{TBranch, TBranchElement}) = b.fEntries
 Base.eachindex(b::Union{TBranch, TBranchElement}) = Base.OneTo(b.fEntries)
 function Base.eltype(b::Union{TBranch, TBranchElement})

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -90,7 +90,7 @@ mutable struct LazyBranch{T, J} <: AbstractVector{T}
 end
 
 function Base.hash(lb::LazyBranch, h::UInt)
-    h = hash(lb.f.filename, h)
+    h = hash(lb.f, h)
     h = hash(lb.b.fClassName, h)
     h = hash(lb.L, h)
     h = hash(lb.buffer_range, h)

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -80,16 +80,22 @@ mutable struct LazyBranch{T, J} <: AbstractVector{T}
     b::Union{TBranch, TBranchElement}
     L::Int64
     fEntry::Vector{Int64}
-    buffer_seek::Int64
     buffer::Vector{T}
     buffer_range::UnitRange{Int64}
 
     function LazyBranch(f::ROOTFile, b::Union{TBranch, TBranchElement})
         T, J = auto_T_JaggT(b; customstructs = f.customstructs)
-        new{T, J}(f, b, length(b), b.fBasketEntry, -1, T[], 0:0)
+        new{T, J}(f, b, length(b), b.fBasketEntry, T[], 0:0)
     end
 end
 
+function Base.hash(lb::LazyBranch, h::UInt)
+    h = hash(lb.f.filename, h)
+    h = hash(lb.b.fClassName, h)
+    h = hash(lb.L, h)
+    h = hash(lb.buffer_range, h)
+    h
+end
 Base.size(ba::LazyBranch) = (ba.L,)
 Base.length(ba::LazyBranch) = ba.L
 Base.firstindex(ba::LazyBranch) = 1

--- a/src/root.jl
+++ b/src/root.jl
@@ -17,6 +17,9 @@ struct ROOTFile
 end
 lock(f::ROOTFile) = lock(f.lk)
 unlock(f::ROOTFile) = unlock(f.lk)
+function Base.hash(rf::ROOTFile, h::UInt)
+    hash(rf.fobj, h)
+end
 
 function ROOTFile(filename::AbstractString; customstructs = Dict("TLorentzVector" => LorentzVector{Float64}))
     fobj = Base.open(filename)


### PR DESCRIPTION
Profiling points out that `findfirst` is too expensive to run for the purpose of checking cache validation.
this PR adds a `UnitRange` to LazyBranch so we can check cache validation with 2 comparison op.

```
julia> size(tree)
(774946, 4)

# BEFORE
julia> @time looper(tree);
  0.230265 seconds (8.34 k allocations: 7.672 MiB)

# THIS PR
julia> @time looper(tree);
  0.053651 seconds (16.67 k allocations: 9.431 MiB)
```
