### PR TITLE
Reading non jagged TLeafElement

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -231,6 +231,7 @@ const _leaftypeconstlookup = Dict(
                              Const.kULong64 =>UInt64,
                              Const.kDouble32 => Float32,
                              Const.kDouble =>   Float64,
+                             Const.kFloat => Float32,
                             )
 
 """

--- a/src/root.jl
+++ b/src/root.jl
@@ -286,6 +286,9 @@ function auto_T_JaggT(branch; customstructs::Dict{String, Type})
             leaftype = _normalize_ftype(leaf.fType)
             _type = get(_leaftypeconstlookup, leaftype, nothing)
             isnothing(_type) && error("Cannot interpret type.")
+            if branch.fType == Const.kSubbranchSTLCollection
+                _type = Vector{_type}
+            end
         end
     else
         _type = primitivetype(leaf)

--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -298,6 +298,7 @@ struct TObjArray
     low::Int32
     elements
 end
+Base.getindex(obj::TObjArray, index) = obj.elements[index]
 
 function unpack(io, tkey::TKey, refs::Dict{Int32, Any}, T::Type{TObjArray})
     preamble = Preamble(io, T)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -58,6 +58,6 @@ struct Offsetjagg  <:JaggType  end
 function JaggType(leaf)
     # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L144
     (match(r"\[.*\]", leaf.fTitle) !== nothing) && return Nooffsetjagg
-    leaf isa TLeafElement && return Offsetjagg
+    leaf isa TLeafElement && leaf.fLenType==0 && return Offsetjagg
     return Nojagg
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -378,9 +378,11 @@ end
 
     # issue 55
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "cms_ntuple_wjet.root"))
-    pts = UnROOT.array(rootfile, "variable/met_p4/fCoordinates/fCoordinates.fPt"; raw=false)
-    @test 24 == length(pts)
-    @test Float32[69.96958, 25.149912, 131.66693, 150.56802] == pts[1:4]
+    pts1 = UnROOT.array(rootfile, "variable/met_p4/fCoordinates/fCoordinates.fPt"; raw=false)
+    pts2 = LazyTree(rootfile, "variable", [r"met_p4/fCoordinates/.*", "mll"])[!, Symbol("met_p4/fCoordinates/fCoordinates.fPt")]
+    @test 24 == length(pts1)
+    @test Float32[69.96958, 25.149912, 131.66693, 150.56802] == pts1[1:4]
+    @test pts1 == pts2
 end
 
 @testset "jagged subbranch type by leaf" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -380,9 +380,11 @@ end
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "cms_ntuple_wjet.root"))
     pts1 = UnROOT.array(rootfile, "variable/met_p4/fCoordinates/fCoordinates.fPt"; raw=false)
     pts2 = LazyTree(rootfile, "variable", [r"met_p4/fCoordinates/.*", "mll"])[!, Symbol("met_p4/fCoordinates/fCoordinates.fPt")]
+    pts3 = rootfile["variable/good_jets_p4/good_jets_p4.fCoordinates.fPt"]
     @test 24 == length(pts1)
     @test Float32[69.96958, 25.149912, 131.66693, 150.56802] == pts1[1:4]
     @test pts1 == pts2
+    @test pts3[1:2] == [[454.0, 217.5, 89.5, 30.640625], [184.375, 33.28125, 32.28125, 28.46875]]
 end
 
 @testset "jagged subbranch type by leaf" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -375,6 +375,12 @@ end
     @test 2 == length(keys(rootfile))
     @test [1.0, 2.0, 3.0] == UnROOT.array(rootfile, "TreeD/nums")
     @test [1.0, 2.0, 3.0] == UnROOT.array(rootfile, "TreeF/nums")
+
+    # issue 55
+    rootfile = ROOTFile(joinpath(SAMPLES_DIR, "cms_ntuple_wjet.root"))
+    pts = UnROOT.array(rootfile, "variable/met_p4/fCoordinates/fCoordinates.fPt"; raw=false)
+    @test 24 == length(pts)
+    @test Float32[69.96958, 25.149912, 131.66693, 150.56802] == pts[1:4]
 end
 
 @testset "jagged subbranch type by leaf" begin


### PR DESCRIPTION
Closes issue https://github.com/tamasgal/UnROOT.jl/issues/55.

Now one can do
```julia
julia> f = ROOTFile("/Users/namin/.julia/dev/UnROOT/test/samples/cms_ntuple_wjet.root");

julia> print(UnROOT.array(f, "variable/met_p4/fCoordinates/fCoordinates.fPt"))
Float32[69.96958, 25.149912, 131.66693, 150.56802...
```

Eventually it would be nice if users could read the whole `"ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<float> >"` branch (above x4 for `fPt`, `fEta`, `fPhi`, `fM`) into an array of `LorentzVector`s with a simple
`f["variable/met_p4"]` like with a `TLorentzVector` branch
:)