### PR TITLE
Reduce allocation by ~20%

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -46,7 +46,7 @@ by [`interped_data`](@ref) to translate raw bytes into actual data.
 function basketarray(f::ROOTFile, path::AbstractString, ithbasket)
     return basketarray(f, f[path], ithbasket)
 end
-@memoize LRU(; maxsize=1024^3, by=x -> sum(sizeof, x)) function basketarray(
+function basketarray(
     f::ROOTFile, branch, ithbasket
 )
     # function basketarray(f::ROOTFile, branch, ithbasket)


### PR DESCRIPTION
With this I believe we can remove the LRU cache for interpred data because our LazyBranch cache + ArraysOfArrays is pretty good.

Basically if LRU cache for interpred data works super well, then one probably should just make concrete `tree` instead of having the same content in the form of LRU caches. I kept the raw data cache because there's nothing to re-use in-place there.
