### PR TITLE
Custom iterator improvement

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnROOT"
 uuid = "3cd96dde-e98d-4713-81e9-a4a1b0235ce9"
 authors = ["Tamas Gal", "Jerry Ling", "Johannes Schumann", "Nick Amin"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/custom.jl
+++ b/src/custom.jl
@@ -91,6 +91,11 @@ end
 function readtype(io::IO, T::Type{KM3NETDAQHit})
     T(readtype(io, Int32), read(io, UInt8), read(io, Int32), read(io, UInt8))
 end
+function interped_data(rawdata, rawoffsets, ::Type{Vector{KM3NETDAQHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQHit, skipbytes=10)
+end
+
+
 # Experimental implementation for maximum performance (using reinterpret)
 primitive type DAQHit 80 end
 function Base.getproperty(hit::DAQHit, s::Symbol)
@@ -128,6 +133,10 @@ function readtype(io::IO, T::Type{KM3NETDAQTriggeredHit})
     T(dom_id, channel_id, tdc, tot, trigger_mask)
 end
 
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{KM3NETDAQTriggeredHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQTriggeredHit, skipbytes=10)
+end
+
 struct KM3NETDAQEventHeader
     detector_id::Int32
     run::Int32
@@ -154,4 +163,8 @@ function readtype(io::IO, T::Type{KM3NETDAQEventHeader})
     trigger_mask = readtype(io, UInt64)
     overlays = readtype(io, UInt32)
     T(detector_id, run, frame_index, UTC_seconds, UTC_16nanosecondcycles, trigger_counter, trigger_mask, overlays)
+end
+
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{KM3NETDAQEventHeader}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQEventHeader, jagged=false)
 end

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -144,7 +144,9 @@ function Base.getindex(ba::LazyBranch{T,J,B}, idx::Integer) where {T,J,B}
     if idx ∉ br
         seek_idx = findfirst(x -> x > (idx - 1), ba.fEntry) - 1 #support 1.0 syntax
         bb = basketarray(ba.f, ba.b, seek_idx)
-        @assert typeof(bb) === B
+        if typeof(bb) !== B
+            error("Expected type of interpreted data: $(B), got: $(typeof(bb))")
+        end
         ba.buffer = bb
         br = (ba.fEntry[seek_idx] + 1):(ba.fEntry[seek_idx + 1] - 1)
         ba.buffer_range = br

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -46,10 +46,7 @@ by [`interped_data`](@ref) to translate raw bytes into actual data.
 function basketarray(f::ROOTFile, path::AbstractString, ithbasket)
     return basketarray(f, f[path], ithbasket)
 end
-function basketarray(
-    f::ROOTFile, branch, ithbasket
-)
-    # function basketarray(f::ROOTFile, branch, ithbasket)
+function basketarray(f::ROOTFile, branch, ithbasket)
     ismissing(branch) && error("No branch found at $path")
     length(branch.fLeaves.elements) > 1 && error(
         "Branches with multiple leaves are not supported yet. Try reading with `array(...; raw=true)`.",

--- a/src/root.jl
+++ b/src/root.jl
@@ -302,10 +302,22 @@ function auto_T_JaggT(f::ROOTFile, branch; customstructs::Dict{String, Type})
     _jaggtype = JaggType(f, branch, leaf)
     if hasproperty(branch, :fClassName)
         classname = branch.fClassName # the C++ class name, such as "vector<int>"
+        parentname = branch.fParentName  # assuming it has a parent ;)
         try
             # this will call a customize routine if defined by user
             # see custom.jl
-            _custom = customstructs[classname]
+            #
+            # TODO to be verified: fields of custom classes have the same classname and parentname,
+            # the fieldname is the fTitle. Here, we use the dot-separator, so that the
+            # user can provide e.g. `KM3NETDAQ::JDAQEvent.snapshotHits`, where `KM3NETDAQ::JDAQEvent`
+            # is the class name and `snapshotHits` the field name. The provided type will be used
+            # to parse the data
+            if classname == parentname
+                identifier = join([classname, branch.fTitle], '.')
+            else
+                identifier = classname
+            end
+            _custom = customstructs[identifier]
             return _custom, Nojagg
         catch
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -319,46 +319,68 @@ end
 # Custom bootstrap things
 
 @testset "custom boostrapping" begin
-    f = ROOTFile(joinpath(SAMPLES_DIR, "km3net_online.root"))
-    data, offsets = UnROOT.array(f, "KM3NET_EVENT/KM3NET_EVENT/snapshotHits"; raw=true)
-    event_hits = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQHit; skipbytes=10)
-    @test length(event_hits) == 3
-    @test length(event_hits[1]) == 96
-    @test length(event_hits[2]) == 124
-    @test length(event_hits[3]) == 78
-    @test event_hits[1][1].dom_id == 806451572
-    @test event_hits[1][1].tdc == 30733918
-    @test event_hits[1][end].dom_id == 809544061
-    @test event_hits[1][end].tdc == 30735112
-    @test event_hits[3][1].dom_id == 806451572
-    @test event_hits[3][1].tdc == 63512204
-    @test event_hits[3][end].dom_id == 809544061
-    @test event_hits[3][end].tdc == 63512892
+    # manual interpretation (splitting)
+    f_manual = ROOTFile(joinpath(SAMPLES_DIR, "km3net_online.root"))
 
-    data, offsets = UnROOT.array(f, "KM3NET_EVENT/KM3NET_EVENT/KM3NETDAQ::JDAQEventHeader"; raw=true)
-    headers = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQEventHeader; jagged=false)
-    @test length(headers) == 3
-    for header in headers
-        @test header.run == 6633
-        @test header.detector_id == 44
-        @test header.UTC_seconds == 0x5dc6018c
+    data, offsets = UnROOT.array(f_manual, "KM3NET_EVENT/KM3NET_EVENT/KM3NETDAQ::JDAQEventHeader"; raw=true)
+    headers_manual = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQEventHeader; jagged=false)
+
+    data, offsets = UnROOT.array(f_manual, "KM3NET_EVENT/KM3NET_EVENT/snapshotHits"; raw=true)
+    event_hits_manual = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQHit; skipbytes=10)
+
+    close(f_manual)  # we can close, everything is in memory
+
+    # automatic interpretation
+    customstructs = Dict(
+            "KM3NETDAQ::JDAQEvent.snapshotHits" => Vector{UnROOT.KM3NETDAQHit},
+            "KM3NETDAQ::JDAQEvent.triggeredHits" => Vector{UnROOT.KM3NETDAQTriggeredHit},
+            "KM3NETDAQ::JDAQEvent.KM3NETDAQ::JDAQEventHeader" => UnROOT.KM3NETDAQEventHeader
+    )
+    f_auto = UnROOT.ROOTFile(joinpath(SAMPLES_DIR, "km3net_online.root"), customstructs=customstructs)
+    headers_auto = f_auto["KM3NET_EVENT/KM3NET_EVENT/KM3NETDAQ::JDAQEventHeader"]
+    event_hits_auto = f_auto["KM3NET_EVENT/KM3NET_EVENT/snapshotHits"]
+    event_thits_auto = f_auto["KM3NET_EVENT/KM3NET_EVENT/triggeredHits"]
+
+    for event_hits ∈ [event_hits_manual, event_hits_auto]
+        @test length(event_hits) == 3
+        @test length(event_hits[1]) == 96
+        @test length(event_hits[2]) == 124
+        @test length(event_hits[3]) == 78
+        @test event_hits[1][1].dom_id == 806451572
+        @test event_hits[1][1].tdc == 30733918
+        @test event_hits[1][end].dom_id == 809544061
+        @test event_hits[1][end].tdc == 30735112
+        @test event_hits[3][1].dom_id == 806451572
+        @test event_hits[3][1].tdc == 63512204
+        @test event_hits[3][end].dom_id == 809544061
+        @test event_hits[3][end].tdc == 63512892
     end
-    @test headers[1].frame_index == 127
-    @test headers[2].frame_index == 127
-    @test headers[3].frame_index == 129
-    @test headers[1].UTC_16nanosecondcycles == 0x029b9270
-    @test headers[2].UTC_16nanosecondcycles == 0x029b9270
-    @test headers[3].UTC_16nanosecondcycles == 0x035a4e90
-    @test headers[1].trigger_counter == 0
-    @test headers[2].trigger_counter == 1
-    @test headers[3].trigger_counter == 0
-    @test headers[1].trigger_mask == 22
-    @test headers[2].trigger_mask == 22
-    @test headers[3].trigger_mask == 4
-    @test headers[1].overlays == 6
-    @test headers[2].overlays == 21
-    @test headers[3].overlays == 0
-    close(f)
+
+    for headers ∈ [headers_manual, headers_auto]
+        @test length(headers) == 3
+        for header in headers
+            @test header.run == 6633
+            @test header.detector_id == 44
+            @test header.UTC_seconds == 0x5dc6018c
+        end
+        @test headers[1].frame_index == 127
+        @test headers[2].frame_index == 127
+        @test headers[3].frame_index == 129
+        @test headers[1].UTC_16nanosecondcycles == 0x029b9270
+        @test headers[2].UTC_16nanosecondcycles == 0x029b9270
+        @test headers[3].UTC_16nanosecondcycles == 0x035a4e90
+        @test headers[1].trigger_counter == 0
+        @test headers[2].trigger_counter == 1
+        @test headers[3].trigger_counter == 0
+        @test headers[1].trigger_mask == 22
+        @test headers[2].trigger_mask == 22
+        @test headers[3].trigger_mask == 4
+        @test headers[1].overlays == 6
+        @test headers[2].overlays == 21
+        @test headers[3].overlays == 0
+    end
+
+    close(f_auto)
 end
 
 # Histograms


### PR DESCRIPTION
This is just a slight improvement to allow access to interpretation of fields of custom classes using the dot-separator.

With this, the following is possible to parse triggered hits of the KM3NeT neutrino detector:

```julia
struct KM3NETDAQTriggeredHit <: UnROOT.CustomROOTStruct
    dom_id::Int32
    channel_id::UInt8
    t::Int32
    tot::UInt8
    trigger_mask::UInt64
end
UnROOT.packedsizeof(::Type{KM3NETDAQTriggeredHit}) = 24  # incl. cnt and vers

function UnROOT.readtype(io, T::Type{KM3NETDAQTriggeredHit})
    dom_id = UnROOT.readtype(io, Int32)
    channel_id = read(io, UInt8)
    tdc = read(io, Int32)
    tot = read(io, UInt8)
    cnt = read(io, UInt32)
    vers = read(io, UInt16)
    trigger_mask = UnROOT.readtype(io, UInt64)
    T(dom_id, channel_id, tdc, tot, trigger_mask)
end

function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{KM3NETDAQTriggeredHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQTriggeredHit, skipbytes=10)
end

customstructs = Dict(
            "KM3NETDAQ::JDAQEvent.snapshotHits" => Vector{KM3NETDAQSnapshotHit},
            "KM3NETDAQ::JDAQEvent.triggeredHits" => Vector{KM3NETDAQTriggeredHit},
            "KM3NETDAQ::JDAQEvent.KM3NETDAQ::JDAQEventHeader" => KM3NETDAQEventHeader
)
fobj = UnROOT.ROOTFile(filename, customstructs=customstructs)
```

and then 

```julia
branch = fobj["KM3NET_EVENT/KM3NET_EVENT/triggeredHits"]
for triggered_hits in branch
    # triggered_hits is now a Vector{KM3NETDAQTriggeredHit} in each iteration (corresponding to one event per it)
end
```