### PR TITLE
make branch basket buffer threadlocal

### DIFF
--- a/src/UnROOT.jl
+++ b/src/UnROOT.jl
@@ -9,8 +9,10 @@ import AbstractTrees: children, printnode, print_tree
 
 using CodecZlib, CodecLz4, CodecXz, CodecZstd, StaticArrays, LorentzVectors, ArraysOfArrays
 using Mixers, Parameters, Memoization, LRUCache
+using Base.Threads
 
 import Tables, TypedTables, PrettyTables, DataFrames
+
 
 @static if VERSION < v"1.4"
     Base.first(a::AbstractVector{S}, n::Integer) where S<: AbstractString = a[1:(length(a) > n ? n : end)]

--- a/src/UnROOT.jl
+++ b/src/UnROOT.jl
@@ -9,10 +9,8 @@ import AbstractTrees: children, printnode, print_tree
 
 using CodecZlib, CodecLz4, CodecXz, CodecZstd, StaticArrays, LorentzVectors, ArraysOfArrays
 using Mixers, Parameters, Memoization, LRUCache
-using Base.Threads
 
 import Tables, TypedTables, PrettyTables, DataFrames
-
 
 @static if VERSION < v"1.4"
     Base.first(a::AbstractVector{S}, n::Integer) where S<: AbstractString = a[1:(length(a) > n ? n : end)]

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -194,9 +194,9 @@ Base.firstindex(lt::LazyTree) = 1
 Base.lastindex(lt::LazyTree) = length(lt)
 
 # allow enumerate() to be chunkable (eg with Threads.@threads)
-Base.firstindex(e::Iterators.Enumerate) = firstindex(e.itr)
-Base.lastindex(e::Iterators.Enumerate) = lastindex(e.itr)
-Base.getindex(e::Iterators.Enumerate, row::Int) = (row, first(iterate(e.itr, row)))
+Base.firstindex(e::Iterators.Enumerate{LazyTree{T}}) where T = firstindex(e.itr)
+Base.lastindex(e::Iterators.Enumerate{LazyTree{T}}) where T = lastindex(e.itr)
+Base.getindex(e::Iterators.Enumerate{LazyTree{T}}, row::Int) where T = (row, first(iterate(e.itr, row)))
 
 # interfacing AbstractDataFrame
 DataFrames._check_consistency(lt::LazyTree) = nothing #we're read-only

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -100,8 +100,8 @@ mutable struct LazyBranch{T,J,B} <: AbstractVector{T}
         _buffer = J === Nojagg ? T[] : VectorOfVectors{eltype(T)}()
         return new{T,J,typeof(_buffer)}(f, b, length(b),
                                         b.fBasketEntry,
-                                        [_buffer for _ in 1:nthreads()],
-                                        [0:0 for _ in 1:nthreads()])
+                                        [_buffer for _ in 1:Threads.nthreads()],
+                                        [0:0 for _ in 1:Threads.nthreads()])
     end
 end
 
@@ -145,7 +145,7 @@ and update buffer and buffer range accordingly.
     performance issue and incorrect event result.
 """
 function Base.getindex(ba::LazyBranch{T,J,B}, idx::Integer) where {T,J,B}
-    tid = threadid()
+    tid = Threads.threadid()
     br = ba.buffer_range[tid]
     if idx ∉ br
         seek_idx = findfirst(x -> x > (idx - 1), ba.fEntry) - 1 #support 1.0 syntax

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -196,7 +196,7 @@ Base.lastindex(lt::LazyTree) = length(lt)
 # allow enumerate() to be chunkable (eg with Threads.@threads)
 Base.firstindex(e::Iterators.Enumerate) = firstindex(e.itr)
 Base.lastindex(e::Iterators.Enumerate) = lastindex(e.itr)
-Base.getindex(e::Iterators.Enumerate, row::Int) = (row - firstindex(e) + 1, getindex(e.itr, row))
+Base.getindex(e::Iterators.Enumerate, row::Int) = (row, first(iterate(e.itr, row)))
 
 # interfacing AbstractDataFrame
 DataFrames._check_consistency(lt::LazyTree) = nothing #we're read-only

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -193,6 +193,11 @@ Base.getindex(lt::LazyTree, ::Colon) = lt[1:end]
 Base.firstindex(lt::LazyTree) = 1
 Base.lastindex(lt::LazyTree) = length(lt)
 
+# allow enumerate() to be chunkable (eg with Threads.@threads)
+Base.firstindex(e::Iterators.Enumerate) = firstindex(e.itr)
+Base.lastindex(e::Iterators.Enumerate) = lastindex(e.itr)
+Base.getindex(e::Iterators.Enumerate, row::Int) = (row - firstindex(e) + 1, getindex(e.itr, row))
+
 # interfacing AbstractDataFrame
 DataFrames._check_consistency(lt::LazyTree) = nothing #we're read-only
 Base.names(lt::LazyTree) = collect(String.(propertynames(innertable(lt))))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -510,11 +510,6 @@ end
     end
     @test nmu == 878
 
-    nmus = [0]
-    Threads.@threads for (i,evt) in enumerate(t)
-        nmus[1] += length(t.Muon_pt[i])
-    end
-    @test nmus == [878]
 
     nmus = [0]
     Threads.@threads for i in 1:length(t)
@@ -522,11 +517,20 @@ end
     end
     @test nmus == [878]
 
-    nmus = [0]
-    Threads.@threads for evt in t
-        nmus[1] += length(evt.Muon_pt)
+
+    @static if VERSION > v"1.3.1"
+        nmus = [0]
+        Threads.@threads for (i,evt) in enumerate(t)
+            nmus[1] += length(t.Muon_pt[i])
+        end
+        @test nmus == [878]
+
+        nmus = [0]
+        Threads.@threads for evt in t
+            nmus[1] += length(evt.Muon_pt)
+        end
+        @test nmus == [878]
     end
-    @test nmus == [878]
 
     et = enumerate(t)
     @test firstindex(et) == firstindex(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -495,3 +495,40 @@ end
 
     close(rootfile)
 end
+
+@testset "Enumerate interface" begin
+    t = LazyTree(ROOTFile(joinpath(SAMPLES_DIR, "NanoAODv5_sample.root")), "Events", ["Muon_pt"])
+    nmu = 0
+    for evt in t
+        nmu += length(evt.Muon_pt)
+    end
+    @test nmu == 878
+
+    nmu = 0
+    for (i,evt) in enumerate(t)
+        nmu += length(evt.Muon_pt)
+    end
+    @test nmu == 878
+
+    nmus = [0]
+    Threads.@threads for (i,evt) in enumerate(t)
+        nmus[1] += length(t.Muon_pt[i])
+    end
+    @test nmus == [878]
+
+    nmus = [0]
+    Threads.@threads for i in 1:length(t)
+        nmus[1] += length(t.Muon_pt[i])
+    end
+    @test nmus == [878]
+
+    nmus = [0]
+    Threads.@threads for evt in t
+        nmus[1] += length(evt.Muon_pt)
+    end
+    @test nmus == [878]
+
+    i,evt = enumerate(t)[2]
+    @test i == 2
+    @test evt isa UnROOT.LazyEvent
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -528,7 +528,11 @@ end
     end
     @test nmus == [878]
 
-    i,evt = enumerate(t)[2]
+    et = enumerate(t)
+    @test firstindex(et) == firstindex(t)
+    @test lastindex(et) == lastindex(t)
+    i,evt = et[2]
     @test i == 2
     @test evt isa UnROOT.LazyEvent
+    @test !isempty(hash(t.Muon_pt.b))
 end


### PR DESCRIPTION
In each of the branch objects, the last-read basket data is stored. If one tried to naively `@threads` an event loop, there would be huge contention in this buffer cache. This PR makes `nthreads()` such buffer caches.

```julia
using UnROOT
using LVCyl
using FHist
using Base.Threads

const f = ROOTFile("Run2012BC_DoubleMuParked_Muons.root")
const t = LazyTree(f, "Events", ["nMuon", r"^Muon_(pt|eta|phi|mass|charge)"])

const hmass = Hist1D(Int64; bins=0:0.001:150)
@time @threads for (i,evt) in enumerate(t)
    evt.nMuon != 2 && continue
    sum(evt.Muon_charge) != 0 && continue
    lvs = LorentzVectorCyl.(evt.Muon_pt, evt.Muon_eta, evt.Muon_phi, evt.Muon_mass)
    mass = sum(lvs).mass
    push!(hmass, mass) # rename to atomic_push eventually
end
```
gives
```julia
27.897073 seconds (49.06 M allocations: 39.579 GiB, 23.23% gc time) # with @threads
68.897655 seconds (48.65 M allocations: 38.559 GiB, 7.48% gc time) # without @threads
```
for julia with 4 threads on a mac laptop. That's about a 2.5x speedup (consistent with me seeing 300% cpu usage instead of 400%).

Note that I commented out the LRU cache around `readbasketseek()` in both cases to keep RAM usage low (seems to go beyond the advertised `maxsize=1024^3` 🤷)


The example comes from https://github.com/tamasgal/UnROOT.jl/issues/73 .


