### PR TITLE
prevent double basket reading

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -148,7 +148,7 @@ function Base.getindex(ba::LazyBranch{T,J,B}, idx::Integer) where {T,J,B}
             error("Expected type of interpreted data: $(B), got: $(typeof(bb))")
         end
         ba.buffer = bb
-        br = (ba.fEntry[seek_idx] + 1):(ba.fEntry[seek_idx + 1] - 1)
+        br = (ba.fEntry[seek_idx] + 1):(ba.fEntry[seek_idx + 1])
         ba.buffer_range = br
     end
     localidx = idx - br.start + 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -522,25 +522,25 @@ end
     @test nmu == 878
 
 
-    nmus = [0]
+    nmus = zeros(Int, Threads.nthreads())
     Threads.@threads for i in 1:length(t)
-        nmus[1] += length(t.Muon_pt[i])
+        nmus[Threads.threadid()] += length(t.Muon_pt[i])
     end
-    @test nmus == [878]
+    @test sum(nmus) == 878
 
 
     @static if VERSION > v"1.3.1"
-        nmus = [0]
+        nmus = zeros(Int, Threads.nthreads())
         Threads.@threads for (i,evt) in enumerate(t)
-            nmus[1] += length(t.Muon_pt[i])
+            nmus[Threads.threadid()] += length(t.Muon_pt[i])
         end
-        @test nmus == [878]
+        @test sum(nmus) == 878
 
-        nmus = [0]
+        nmus = zeros(Int, Threads.nthreads())
         Threads.@threads for evt in t
-            nmus[1] += length(evt.Muon_pt)
+            nmus[Threads.threadid()] += length(evt.Muon_pt)
         end
-        @test nmus == [878]
+        @test sum(nmus) == 878
     end
 
     et = enumerate(t)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -464,11 +464,7 @@ end
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "issue61.root"))
     arr = LazyTree(rootfile,"Events").Jet_pt;
     _ = length.(arr);
-    if length(arr.buffer) == Threads.nthreads()
-        @test length(arr.buffer[1]) == length(arr.buffer_range[1])
-    else
-        @test length(arr.buffer) == length(arr.buffer_range)
-    end
+    @test length(arr.buffer[1]) == length(arr.buffer_range[1])
     close(rootfile)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -455,6 +455,17 @@ end
     rootfile = ROOTFile(joinpath(SAMPLES_DIR, "issue61.root"))
     @test rootfile["Events/Jet_pt"][:] == Vector{Float32}[[], [27.324587, 24.889547, 20.853024], [], [20.33066], [], []]
     close(rootfile)
+
+    # issue 78
+    rootfile = ROOTFile(joinpath(SAMPLES_DIR, "issue61.root"))
+    arr = LazyTree(rootfile,"Events").Jet_pt;
+    _ = length.(arr);
+    if length(arr.buffer) == Threads.nthreads()
+        @test length(arr.buffer[1]) == length(arr.buffer_range[1])
+    else
+        @test length(arr.buffer) == length(arr.buffer_range)
+    end
+    close(rootfile)
 end
 
 @testset "jagged subbranch type by leaf" begin


### PR DESCRIPTION
Closes https://github.com/tamasgal/UnROOT.jl/issues/78

We were unnecessarily reading baskets a second time when on the boundary of the next basket because `buffer_range` advertises one less element than we actually cache, so `getindex()` tries to re-read that entry.
```julia
julia> using UnROOT

julia> const t = LazyTree(ROOTFile("/Users/namin/sandbox/miscnotebooks/julia/Run2012BC_DoubleMuParked_Muons.root"), "Events", ["Muon_pt"])

julia> length(t.Muon_pt.buffer) # number of events we cache
734983

julia> length(t.Muon_pt.buffer_range) # number we advertise we cache
734982
```

### Before
```julia
julia> @time sum(length.(t.Muon_pt))
  4.812074 seconds (43.89 k allocations: 3.605 GiB, 11.14% gc time)
149322456
```

### After
```julia
julia> @time sum(length.(t.Muon_pt))
  2.784472 seconds (21.95 k allocations: 2.032 GiB, 3.90% gc time)
149322456
```

which gets us about a 2x speedup and reduction in allocations for anything that reads iteratively and touches more than 1 basket. 🚀 