### PR TITLE
add more information in LazyEvent printout

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -279,7 +279,8 @@ function Base.show(io::IO, evt::LazyEvent)
     idx = Core.getfield(evt, :idx)
     fields = propertynames(Core.getfield(evt, :tree))
     nfields = length(fields)
-    show(io, "LazyEvent $(idx) with $(nfields) fields: $(fields)")
+    sfields = nfields < 20 ? ": $(fields)" : ""
+    show(io, "LazyEvent $(idx) with $(nfields) fields$(sfields)")
 end
 function Base.getproperty(evt::LazyEvent, s::Symbol)
     @inbounds getproperty(Core.getfield(evt, :tree), s)[Core.getfield(evt, :idx)]

--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -275,7 +275,12 @@ struct LazyEvent{T<:TypedTables.Table}
     tree::T
     idx::Int64
 end
-Base.show(io::IO, evt::LazyEvent) = show(io, "LazyEvent with: $(propertynames(evt))")
+function Base.show(io::IO, evt::LazyEvent)
+    idx = Core.getfield(evt, :idx)
+    fields = propertynames(Core.getfield(evt, :tree))
+    nfields = length(fields)
+    show(io, "LazyEvent $(idx) with $(nfields) fields: $(fields)")
+end
 function Base.getproperty(evt::LazyEvent, s::Symbol)
     @inbounds getproperty(Core.getfield(evt, :tree), s)[Core.getfield(evt, :idx)]
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -293,6 +293,7 @@ end
     @test sort(propertynames(tree)) == sort([:Muon_pt, :Muon_eta, :Muon_phi, :Muon_charge])
     tree = LazyTree(rootfile, "Events", r"Muon_(pt|eta)$")
     @test sort(propertynames(tree)) == sort([:Muon_pt, :Muon_eta])
+    @test occursin("LazyEvent", repr(first(iterate(tree))))
     close(rootfile)
 end
 


### PR DESCRIPTION
Add the index number and field names to the `LazyEvent` string representation. This is with `julia -t 4`, as an example.
```julia
julia> using UnROOT, Polyester

julia> const t = LazyTree(ROOTFile(joinpath(UnROOT.@__DIR__, "../test/samples/NanoAODv5_sample.root")),"Events", ["Jet_pt","nJet"]);
```

before:
```julia
julia> @batch for evt in t
           @show evt
           break
       end
evt = "LazyEvent with: (:tree, :idx)"
evt = "LazyEvent with: (:tree, :idx)"
evt = "LazyEvent with: (:tree, :idx)"
evt = "LazyEvent with: (:tree, :idx)"
```
after:
```julia
julia> @batch for evt in t
           @show evt
           break
       end
evt = "LazyEvent 751 with 2 fields: (:Jet_pt, :nJet)"
evt = "LazyEvent 1 with 2 fields: (:Jet_pt, :nJet)"
evt = "LazyEvent 501 with 2 fields: (:Jet_pt, :nJet)"
evt = "LazyEvent 251 with 2 fields: (:Jet_pt, :nJet)"
```
