### PR TITLE
clean up confusing `origin()` and fix uncompressed reading

### DIFF
--- a/src/streamers.jl
+++ b/src/streamers.jl
@@ -193,7 +193,7 @@ The `refs` dictionary holds the streamers or parsed data which are reused
 when already available.
 """
 function readobjany!(io, tkey::TKey, refs)
-    beg = position(io) - origin(tkey)
+    beg = position(io) + tkey.fKeylen
     bcnt = readtype(io, UInt32)
     if Int64(bcnt) & Const.kByteCountMask == 0 || Int64(bcnt) == Const.kNewClassTag
         # New class or 0 bytes
@@ -203,7 +203,7 @@ function readobjany!(io, tkey::TKey, refs)
         bcnt = 0
     else
         version = 1
-        start = position(io) - origin(tkey)
+        start = position(io) + tkey.fKeylen
         tag = readtype(io, UInt32)
     end
 
@@ -215,7 +215,7 @@ function readobjany!(io, tkey::TKey, refs)
             error("Returning parent is not implemented yet")
         elseif !haskey(refs, tag)
             # skipping
-            seek(io, origin(tkey) + beg + bcnt + 4)
+            seek(io, -tkey.fKeylen + beg + bcnt + 4)
             return missing
         else
             return refs[tag]

--- a/src/types.jl
+++ b/src/types.jl
@@ -87,7 +87,6 @@ function unpack(io, T::Type{TBasketKey})
 end
 
 iscompressed(t::T) where T<:Union{TKey, TBasketKey} = t.fObjlen != t.fNbytes - t.fKeylen
-origin(t::T) where T<:Union{TKey, TBasketKey} = iscompressed(t) ? -t.fKeylen : t.fSeekKey
 seekstart(io, t::T) where T<:Union{TKey, TBasketKey} = seek(io, t.fSeekKey + t.fKeylen)
 
 datastream(io, tkey::TKey) = IOBuffer(decompress_datastreambytes(compressed_datastream(io, tkey), tkey))
@@ -101,12 +100,6 @@ because we want to compartmentalize disk I/O as much as possible.
 See also: [`decompress_datastreambytes`](@ref)
 """
 function compressed_datastream(io, tkey)
-    if !iscompressed(tkey)
-        @debug ("Uncompressed datastream of $(tkey.fObjlen) bytes " *
-                "at $start (TKey '$(tkey.fName)' ($(tkey.fClassName)))")
-        skip(io, 1)   # ???
-        return read(io, tkey.fObjlen)
-    end
     seekstart(io, tkey)
     return read(io, tkey.fNbytes - tkey.fKeylen)
 end


### PR DESCRIPTION
fix #87
