### PR TITLE
reduce allocation by 15%

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -442,17 +442,17 @@ function readbasketseek(f::ROOTFile, branch::Union{TBranch, TBranchElement}, see
 
     offsetbytesize = basketkey.fObjlen - contentsize - 8
 
-    data = basketrawbytes[1:contentsize]
     if offsetbytesize > 0
 
-        #indexing is inclusive on both ends
+        # indexing is inclusive on both ends
+        # Notice: need to delay `resize!` to not destory this @view
         offbytes = @view basketrawbytes[(contentsize + 4 + 1):(end - 4)]
 
         # offsets starts at -fKeylen, same as the `local_offset` we pass in in the loop
         offset = ntoh.(reinterpret(Int32, offbytes)) .- Keylen
         push!(offset, contentsize)
-        return data, offset
+        return resize!(basketrawbytes, contentsize), offset
     else
-        return data, Int32[]
+        return resize!(basketrawbytes, contentsize), Int32[]
     end
 end


### PR DESCRIPTION
With the classical test:
```julia
julia> const t = LazyTree(ROOTFile("Run2012BC_DoubleMuParked_Muons.root"), "Events", ["Muon_pt"]);

julia> @benchmark let nmu=0
           for evt in t
               nmu += sum(evt.Muon_pt)
           end
           nmu
       end
```

Before:
```
BenchmarkTools.Trial: 1 sample with 1 evaluation.
 Single result which took 5.104 s (2.01% GC) to evaluate,
 with a memory estimate of 4.72 GiB, over 59724 allocations.
```

After:
```
BenchmarkTools.Trial: 2 samples with 1 evaluation.
 Range (min … max):  4.921 s …  4.931 s  ┊ GC (min … max): 1.24% … 1.29%
 Time  (median):     4.926 s             ┊ GC (median):    1.26%
 Time  (mean ± σ):   4.926 s ± 6.853 ms  ┊ GC (mean ± σ):  1.26% ± 0.04%

  █                                                      █  
  █▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁█ ▁
  4.92 s        Histogram: frequency by time        4.93 s <

 Memory estimate: 4.16 GiB, allocs estimate: 58155.

```