### PR TITLE
aesthetic fixes

### DIFF
--- a/src/displays.jl
+++ b/src/displays.jl
@@ -68,9 +68,9 @@ function _make_header(t)
     (header, subheader)
 end
 function _treeformat(val, trunc)
-    s = if val isa Union{SubArray{T},Vector{T}} where T<:Integer
+    s = if val isa AbstractArray{T} where T<:Integer
         string(Int.(val))
-    elseif val isa Union{SubArray{T},Vector{T}} where T<:AbstractFloat
+    elseif val isa AbstractArray{T} where T<:AbstractFloat
         T = eltype(val)
         replace(string(round.(T.(val); sigdigits=3)), string(T)=>"")
     else

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -71,7 +71,8 @@ function _treeformat(val, trunc)
     s = if val isa Union{SubArray{T},Vector{T}} where T<:Integer
         string(Int.(val))
     elseif val isa Union{SubArray{T},Vector{T}} where T<:AbstractFloat
-        string(round.(Float64.(val); sigdigits=3))
+        T = eltype(val)
+        replace(string(round.(T.(val); sigdigits=3)), string(T)=>"")
     else
         string(val)
     end

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -4,8 +4,8 @@ by using `AbstractTrees` printing functions. We customize what the children
 of ROOTFile and a TTree is, and how to print the final `node`.
 =#
 struct TKeyNode
-    name
-    classname
+    name::AbstractString
+    classname::AbstractString
 end
 function children(f::ROOTFile)
     # display TTrees recursively
@@ -13,8 +13,11 @@ function children(f::ROOTFile)
     ch = Vector{Union{TTree,TKeyNode}}()
     lock(f)
     for k in keys(f)
-        f[k] isa TTree || continue
-        push!(ch, f[k])
+        try
+            f[k] isa TTree || continue
+            push!(ch, f[k])
+        catch
+        end
     end
     for tkey in f.directory.keys
         kn = TKeyNode(tkey.fName, tkey.fClassName)

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -53,7 +53,7 @@ function Base.show(io::IO, tree::LazyTree)
         row_number_column_title="Row",
         show_row_number=true,
         compact_printing=false,
-        formatters=(v, i, j) -> _treeformat(v, _ds[2] ÷ min(5, length(_hs[1]))),
+        formatters=(v, i, j) -> _treeformat(v, _ds[2] ÷ min(8, length(_hs[1]))),
         display_size=(min(_ds[1], 40), min(_ds[2], 160)),
     )
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,3 +99,7 @@ function parseTH(th::Dict{Symbol, Any})
     end
     return counts, edges, sumw2
 end
+
+function samplefile(filename::AbstractString)
+    return ROOTFile(normpath(joinpath(@__DIR__, "../test/samples", filename)))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -340,9 +340,12 @@ end
 
 @testset "Displaying trees" begin
     f = UnROOT.samplefile("NanoAODv5_sample.root")
-    t = LazyTree(f, "Events", ["nMuon","MET_pt","Muon_pt"])[1:10]
+    t = LazyTree(f, "Events", ["nMuon","MET_pt","Muon_pt"])
     _io = IOBuffer()
     show(_io, t)
+    show(_io, t[1:10])
+    show(_io, t.Muon_pt)
+    show(_io, t.Muon_pt[1:10])
     close(f)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -342,7 +342,7 @@ end
     f = UnROOT.samplefile("NanoAODv5_sample.root")
     t = LazyTree(f, "Events", ["nMuon","MET_pt","Muon_pt"])[1:10]
     _io = IOBuffer()
-    show(_io, f)
+    show(_io, t)
     close(f)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -328,7 +328,7 @@ end
     @test filter_branches(["Muon.pt"]) == Set(["Muon.pt"])
 end
 
-@testset "Displaying" begin
+@testset "Displaying files" begin
     files = filter(endswith(".root"), readdir(SAMPLES_DIR))
     _io = IOBuffer()
     for f in files
@@ -337,6 +337,15 @@ end
         close(r)
     end
 end
+
+@testset "Displaying trees" begin
+    f = UnROOT.samplefile("NanoAODv5_sample.root")
+    t = LazyTree(f, "Events", ["nMuon","MET_pt","Muon_pt"])[1:10]
+    _io = IOBuffer()
+    show(_io, f)
+    close(f)
+end
+
 # Custom bootstrap things
 
 @testset "custom boostrapping" begin


### PR DESCRIPTION
closes https://github.com/tamasgal/UnROOT.jl/issues/96

- Added `UnROOT.samplefile("treehist.root")` to make copy-pasting easier
- Fixed regression in tree pretty-printing
- Print out (name, classname) for all TKeys other than TTrees

## before
```julia
julia> UnROOT.samplefile("treehist.root")
ROOTFile with 5 entries and 23 streamers.
/Users/namin/.julia/dev/UnROOT/test/samples/treehist.root
└─ Events (TTree)
   └─ "Jet_pt"
```

## after
```julia
julia> UnROOT.samplefile("treehist.root")
ROOTFile with 5 entries and 23 streamers.
/Users/namin/.julia/dev/UnROOT/test/samples/treehist.root
├─ Events (TTree)
│  └─ "Jet_pt"
├─ myTH1F (TH1F)
├─ myTH1D (TH1D)
├─ myTH2F (TH2F)
└─ myTH2D (TH2D)
```

## before
```julia
julia> t
 Row │ nMuon   Muon_pt                                Muon_eta                               Muon_phi                               Muon_mass                  ⋯
     │ UInt32  Vector{Float32}                        Vector{Float32}                        Vector{Float32}                        Vector{Float32}            ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 1   │ 2       Float32[10.763697, 15.736523]          Float32[1.0668273, -0.5637865]         Float32[-0.034272723, 2.5426154]       Float32[0.10565837, 0.1056 ⋯
 2   │ 2       Float32[10.53849, 16.327097]           Float32[-0.42778006, 0.34922507]       Float32[-0.2747921, 2.5397813]         Float32[0.10565837, 0.1056 ⋯
 3   │ 1       Float32[3.2753265]                     Float32[2.2108555]                     Float32[-1.2234136]                    Float32[0.10565837]        ⋯
 4   │ 4       Float32[11.429154, 17.634033, 9.62472  Float32[-1.5882396, -1.7511845, -1.59  Float32[-2.0773041, 0.25135836, -2.01  Float32[0.10565837, 0.1056 ⋯
 5   │ 4       Float32[3.2834418, 3.6440058, 32.9112  Float32[-2.1724837, -2.182535, -1.123  Float32[-2.3700082, -2.305139, -0.975  Float32[0.10565837, 0.1056 ⋯
 6   │ 3       Float32[3.566528, 4.572504, 4.371863]  Float32[-1.371932, -0.7032646, -1.039  Float32[-2.909045, 2.455208, -3.05939  Float32[0.10565837, 0.1056 ⋯
 7   │ 2       Float32[57.6067, 53.04508]             Float32[-0.5320893, -1.0041686]        Float32[-0.07179804, 3.0895152]        Float32[0.10565837, 0.1056 ⋯
 8   │ 2       Float32[11.319675, 23.906353]          Float32[-0.77165854, -0.700997]        Float32[-2.2452729, -2.1809616]        Float32[0.10565837, 0.1056 ⋯
 9   │ 2       Float32[10.193569, 14.204061]          Float32[0.44180685, 0.70211726]        Float32[0.67785203, -2.034401]         Float32[0.10565837, 0.1056 ⋯
 10  │ 2       Float32[11.470704, 3.4690065]          Float32[2.341742, 2.3523731]           Float32[3.1309705, 3.0211737]          Float32[0.10565837, 0.1056 ⋯
  ⋮  │   ⋮                       ⋮                                      ⋮                                      ⋮                                      ⋮        ⋱
                                                                                                                             2 columns and 61540403 rows omitted
```

## after
```julia
julia> t
 Row │ nMuon   Muon_pt                          Muon_eta                         Muon_phi                         Muon_mass                        Muon_charge ⋯
     │ UInt32  Vector{Float32}                  Vector{Float32}                  Vector{Float32}                  Vector{Float32}                  Vector{Int3 ⋯
─────┼──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 1   │ 2       [10.8, 15.7]                     [1.07, -0.564]                   [-0.0343, 2.54]                  [0.106, 0.106]                   [-1, -1]    ⋯
 2   │ 2       [10.5, 16.3]                     [-0.428, 0.349]                  [-0.275, 2.54]                   [0.106, 0.106]                   [1, -1]     ⋯
 3   │ 1       [3.28]                           [2.21]                           [-1.22]                          [0.106]                          [1]         ⋯
 4   │ 4       [11.4, 17.6, 9.62, 3.5]          [-1.59, -1.75, -1.59, -1.66]     [-2.08, 0.251, -2.01, -1.85]     [0.106, 0.106, 0.106, 0.106]     [1, 1, 1, 1 ⋯
 5   │ 4       [3.28, 3.64, 32.9, 23.7]         [-2.17, -2.18, -1.12, -1.16]     [-2.37, -2.31, -0.975, -0.773]   [0.106, 0.106, 0.106, 0.106]     [-1, -1, 1, ⋯
 6   │ 3       [3.57, 4.57, 4.37]               [-1.37, -0.703, -1.04]           [-2.91, 2.46, -3.06]             [0.106, 0.106, 0.106]            [-1, 1, -1] ⋯
 7   │ 2       [57.6, 53.0]                     [-0.532, -1.0]                   [-0.0718, 3.09]                  [0.106, 0.106]                   [-1, 1]     ⋯
 8   │ 2       [11.3, 23.9]                     [-0.772, -0.701]                 [-2.25, -2.18]                   [0.106, 0.106]                   [1, -1]     ⋯
 9   │ 2       [10.2, 14.2]                     [0.442, 0.702]                   [0.678, -2.03]                   [0.106, 0.106]                   [-1, 1]     ⋯
 10  │ 2       [11.5, 3.47]                     [2.34, 2.35]                     [3.13, 3.02]                     [0.106, 0.106]                   [-1, 1]     ⋯
  ⋮  │   ⋮                    ⋮                                ⋮                                ⋮                                ⋮                          ⋮  ⋱
                                                                                                                              1 column and 61540403 rows omitted
```
