### PR TITLE
more optimizations

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -250,9 +250,8 @@ function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{J}) where {T, J<:J
             offset = rawoffsets
         end
         real_data = ntoh.(reinterpret(T, rawdata))
-        offset .÷= _size
-        offset .+= 1
-        return VectorOfVectors(real_data, offset)
+        offset .= (offset .÷ _size) .+ 1
+        return VectorOfVectors(real_data, offset, ArraysOfArrays.no_consistency_checks)
     end
 end
 


### PR DESCRIPTION
Profiling showed a couple % on separate `materialize` calls for the two offset lines. I guess they weren't being combined? We also were spending a few % in  `full_consistency_checks(A::VectorOfArrays)` . Luckily we can make that a no-op :)

```diff
-        offset .÷= _size
-        offset .+= 1
-        return VectorOfVectors(real_data, offset)
+        offset .= (offset .÷ _size) .+ 1
+        return VectorOfVectors(real_data, offset, ArraysOfArrays.no_consistency_checks)
```



### benchmark

```julia
julia> using UnROOT

julia> const t = LazyTree(ROOTFile("uncompressed_Run2012BC_DoubleMuParked_Muons.root"),"Events");

julia> function foo(t)
           s = 0.0f0
           for evt in t
               s += sum(evt.Muon_pt)
           end
           s
       end
```

### before

```julia
BenchmarkTools.Trial: 15 samples with 1 evaluation.
 Range (min … max):  1.998 s …   2.076 s  ┊ GC (min … max): 5.87% … 5.73%
 Time  (median):     2.018 s              ┊ GC (median):    5.85%
 Time  (mean ± σ):   2.027 s ± 21.783 ms  ┊ GC (mean ± σ):  5.84% ± 0.07%
```

### after

```julia
BenchmarkTools.Trial: 16 samples with 1 evaluation.
 Range (min … max):  1.891 s …   1.940 s  ┊ GC (min … max): 6.22% … 6.12%
 Time  (median):     1.897 s              ┊ GC (median):    6.21%
 Time  (mean ± σ):   1.902 s ± 13.110 ms  ┊ GC (mean ± σ):  6.18% ± 0.06%
```

____

~5% speedup for an uncompressed file reading one branch. Probably means ~2% speedup on the zlib-compressed version.