### PR TITLE
fix bool branch interpretation

### DIFF
--- a/src/root.jl
+++ b/src/root.jl
@@ -193,6 +193,10 @@ on type `T` and jagg type `J`.
 In order to retrieve data from custom branches, user should defined more speialized
 method of this function with specific `T` and `J`. See `TLorentzVector` example.
 """
+function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{Nojagg}) where {T<:Bool}
+    # specialized case to get Vector{Bool} instead of BitVector
+    return map(ntoh,reinterpret(T, rawdata))
+end
 function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{J}) where {T, J<:JaggType}
     # there are two possibility, one is the leaf is just normal leaf but the title has "[...]" in it
     # magic offsets, seems to be common for a lot of types, see auto.py in uproot3
@@ -200,9 +204,9 @@ function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{J}) where {T, J<:J
     # the jaggedness comes from having "[]" in TLeaf's title
     # the other is where we need to auto detector T bsaed on class name
     # we want the fundamental type as `reinterpret` will create vector
-    if J == Nojagg
+    if J === Nojagg
         return ntoh.(reinterpret(T, rawdata))
-    elseif J == Offsetjaggjagg # the branch is doubly jagged
+    elseif J === Offsetjaggjagg # the branch is doubly jagged
         jagg_offset = 10
         subT = eltype(eltype(T))
         out = VectorOfVectors(T(), Int32[1])

--- a/src/root.jl
+++ b/src/root.jl
@@ -193,7 +193,7 @@ on type `T` and jagg type `J`.
 In order to retrieve data from custom branches, user should defined more speialized
 method of this function with specific `T` and `J`. See `TLorentzVector` example.
 """
-function interped_data(rawdata, rawoffsets, ::Type{T}, ::Type{Nojagg}) where {T<:Bool}
+function interped_data(rawdata, rawoffsets, ::Type{Bool}, ::Type{Nojagg})
     # specialized case to get Vector{Bool} instead of BitVector
     return map(ntoh,reinterpret(T, rawdata))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -322,6 +322,7 @@ end
     tree = LazyTree(rootfile, "Events", r"Muon_(pt|eta)$")
     @test sort(propertynames(tree) |> collect) == sort([:Muon_pt, :Muon_eta])
     @test occursin("LazyEvent", repr(first(iterate(tree))))
+    @test sum(rootfile["Events/HLT_Mu3_PFJet40"]) == 443
     close(rootfile)
 end
 


### PR DESCRIPTION
We needed a specialized case to interpret boolean branches as `Vector{Bool}` instead of `BitVector`. I factored out the solution and unit test from https://github.com/tamasgal/UnROOT.jl/pull/95 .

### before
💥🚗 
### after
```julia
julia> using UnROOT

julia> f = UnROOT.samplefile("NanoAODv5_sample.root");

julia> f["Events/L1_ZeroBias"]
1000-element LazyBranch{Bool, UnROOT.Nojagg, Vector{Bool}}:
 1
 1
 1
 1
 1
 1
 1
 ⋮
 1
 1
 1
 1
 1
 1
 1
```

