### PR TITLE
Prefix custom structures with _ to hide them

### DIFF
--- a/docs/src/advanced/custom_branch.md
+++ b/docs/src/advanced/custom_branch.md
@@ -65,7 +65,7 @@ julia> data, offsets = array(f, "KM3NET_EVENT/KM3NET_EVENT/snapshotHits"; raw=tr
  0x03
    ⋮
    
-julia> UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQHit)
-4-element Vector{Vector{UnROOT.KM3NETDAQHit}}:
- [UnROOT.KM3NETDAQHit(1073742790, 0x00, 9, 0x60)......
+julia> UnROOT.splitup(data, offsets, UnROOT._KM3NETDAQHit)
+4-element Vector{Vector{UnROOT._KM3NETDAQHit}}:
+ [UnROOT._KM3NETDAQHit(1073742790, 0x00, 9, 0x60)......
 ```

--- a/src/custom.jl
+++ b/src/custom.jl
@@ -82,17 +82,17 @@ end
 # TLorentzVector ends
 
 # KM3NeT
-struct KM3NETDAQHit <: CustomROOTStruct
+struct _KM3NETDAQHit <: CustomROOTStruct
     dom_id::Int32
     channel_id::UInt8
     tdc::Int32
     tot::UInt8
 end
-function readtype(io::IO, T::Type{KM3NETDAQHit})
+function readtype(io::IO, T::Type{_KM3NETDAQHit})
     T(readtype(io, Int32), read(io, UInt8), read(io, Int32), read(io, UInt8))
 end
-function interped_data(rawdata, rawoffsets, ::Type{Vector{KM3NETDAQHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
-    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQHit, skipbytes=10)
+function interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQHit, skipbytes=10)
 end
 
 
@@ -116,14 +116,14 @@ end
 Base.show(io::IO, h::DAQHit) = print(io, "DAQHit(", h.dom_id, ',', h.channel_id, ',', h.tdc, ',', h.tot, ')')
 
 
-struct KM3NETDAQTriggeredHit
+struct _KM3NETDAQTriggeredHit
     dom_id::Int32
     channel_id::UInt8
     tdc::Int32
     tot::UInt8
     trigger_mask::UInt64
 end
-function readtype(io::IO, T::Type{KM3NETDAQTriggeredHit})
+function readtype(io::IO, T::Type{_KM3NETDAQTriggeredHit})
     dom_id = readtype(io, Int32)
     channel_id = read(io, UInt8)
     tdc = read(io, Int32)
@@ -133,11 +133,11 @@ function readtype(io::IO, T::Type{KM3NETDAQTriggeredHit})
     T(dom_id, channel_id, tdc, tot, trigger_mask)
 end
 
-function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{KM3NETDAQTriggeredHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
-    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQTriggeredHit, skipbytes=10)
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{Vector{_KM3NETDAQTriggeredHit}}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQTriggeredHit, skipbytes=10)
 end
 
-struct KM3NETDAQEventHeader
+struct _KM3NETDAQEventHeader
     detector_id::Int32
     run::Int32
     frame_index::Int32
@@ -147,9 +147,9 @@ struct KM3NETDAQEventHeader
     trigger_mask::UInt64
     overlays::UInt32
 end
-packedsizeof(::Type{KM3NETDAQEventHeader}) = 76
+packedsizeof(::Type{_KM3NETDAQEventHeader}) = 76
 
-function readtype(io::IO, T::Type{KM3NETDAQEventHeader})
+function readtype(io::IO, T::Type{_KM3NETDAQEventHeader})
     skip(io, 18)
     detector_id = readtype(io, Int32)
     run = readtype(io, Int32)
@@ -165,6 +165,6 @@ function readtype(io::IO, T::Type{KM3NETDAQEventHeader})
     T(detector_id, run, frame_index, UTC_seconds, UTC_16nanosecondcycles, trigger_counter, trigger_mask, overlays)
 end
 
-function UnROOT.interped_data(rawdata, rawoffsets, ::Type{KM3NETDAQEventHeader}, ::Type{J}) where {T, J <: UnROOT.JaggType}
-    UnROOT.splitup(rawdata, rawoffsets, KM3NETDAQEventHeader, jagged=false)
+function UnROOT.interped_data(rawdata, rawoffsets, ::Type{_KM3NETDAQEventHeader}, ::Type{J}) where {T, J <: UnROOT.JaggType}
+    UnROOT.splitup(rawdata, rawoffsets, _KM3NETDAQEventHeader, jagged=false)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -376,18 +376,18 @@ end
     f_manual = ROOTFile(joinpath(SAMPLES_DIR, "km3net_online.root"))
 
     data, offsets = UnROOT.array(f_manual, "KM3NET_EVENT/KM3NET_EVENT/KM3NETDAQ::JDAQEventHeader"; raw=true)
-    headers_manual = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQEventHeader; jagged=false)
+    headers_manual = UnROOT.splitup(data, offsets, UnROOT._KM3NETDAQEventHeader; jagged=false)
 
     data, offsets = UnROOT.array(f_manual, "KM3NET_EVENT/KM3NET_EVENT/snapshotHits"; raw=true)
-    event_hits_manual = UnROOT.splitup(data, offsets, UnROOT.KM3NETDAQHit; skipbytes=10)
+    event_hits_manual = UnROOT.splitup(data, offsets, UnROOT._KM3NETDAQHit; skipbytes=10)
 
     close(f_manual)  # we can close, everything is in memory
 
     # automatic interpretation
     customstructs = Dict(
-            "KM3NETDAQ::JDAQEvent.snapshotHits" => Vector{UnROOT.KM3NETDAQHit},
-            "KM3NETDAQ::JDAQEvent.triggeredHits" => Vector{UnROOT.KM3NETDAQTriggeredHit},
-            "KM3NETDAQ::JDAQEvent.KM3NETDAQ::JDAQEventHeader" => UnROOT.KM3NETDAQEventHeader
+            "KM3NETDAQ::JDAQEvent.snapshotHits" => Vector{UnROOT._KM3NETDAQHit},
+            "KM3NETDAQ::JDAQEvent.triggeredHits" => Vector{UnROOT._KM3NETDAQTriggeredHit},
+            "KM3NETDAQ::JDAQEvent.KM3NETDAQ::JDAQEventHeader" => UnROOT._KM3NETDAQEventHeader
     )
     f_auto = UnROOT.ROOTFile(joinpath(SAMPLES_DIR, "km3net_online.root"), customstructs=customstructs)
     headers_auto = f_auto["KM3NET_EVENT/KM3NET_EVENT/KM3NETDAQ::JDAQEventHeader"]


### PR DESCRIPTION
Since the custom stuff is mostly for test coverage, it makes sense to hide it from the public API. Btw. it also collides with downstream code since the structs are usually defined there and otherwise there is a clash, see https://github.com/tamasgal/UnROOT.jl/pull/95#issuecomment-920161597