### PR TITLE
optimize TBasketKey unpacking

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -59,48 +59,46 @@ end
 
 function unpack(io, T::Type{TBasketKey})
     start = position(io)
-    fields = Dict{Symbol, Union{Integer, String}}()
-    sizehint!(fields, length(fieldnames(T)))
 
-    fields[:fNbytes] = readtype(io, Int32)
-    fields[:fVersion] = readtype(io, Int16)  # FIXME if "complete" it's UInt16 (acc. uproot)
+    fNbytes = readtype(io, Int32)
+    fVersion = readtype(io, Int16)  # FIXME if "complete" it's UInt16 (acc. uproot)
 
-    inttype = fields[:fVersion] <= 1000 ? Int32 : Int64
+    inttype = fVersion <= 1000 ? Int32 : Int64
 
-    fields[:fObjlen] = readtype(io, Int32)
-    fields[:fDatime] = readtype(io, UInt32)
-    fields[:fKeylen] = readtype(io, Int16)
-    fields[:fCycle] = readtype(io, Int16)
-    fields[:fSeekKey] = readtype(io, inttype)
-    fields[:fSeekPdir] = readtype(io, inttype)
-    fields[:fClassName] = readtype(io, String)
-    fields[:fName] = readtype(io, String)
-    fields[:fTitle] = readtype(io, String)
+    fObjlen = readtype(io, Int32)
+    fDatime = readtype(io, UInt32)
+    fKeylen = readtype(io, Int16)
+    fCycle = readtype(io, Int16)
+    fSeekKey = readtype(io, inttype)
+    fSeekPdir = readtype(io, inttype)
+    fClassName = readtype(io, String)
+    fName = readtype(io, String)
+    fTitle = readtype(io, String)
 
     # if complete (which is true for compressed, it seems?)
-    seek(io, start + fields[:fKeylen] - 18 - 1)
-    fields[:fVersion] = readtype(io, Int16)  # FIXME if "complete" it's UInt16 (acc. uproot)
-    fields[:fBufferSize] = readtype(io, Int32)
-    fields[:fNevBufSize] = readtype(io, Int32)
-    fields[:fNevBuf] = readtype(io, Int32)
-    fields[:fLast] = readtype(io, Int32)
+    seek(io, start + fKeylen - 18 - 1)
+    fVersion = readtype(io, Int16)  # FIXME if "complete" it's UInt16 (acc. uproot)
+    fBufferSize = readtype(io, Int32)
+    fNevBufSize = readtype(io, Int32)
+    fNevBuf = readtype(io, Int32)
+    fLast = readtype(io, Int32)
 
     T(
-      fields[:fNbytes],
-      fields[:fVersion],
-      fields[:fObjlen],
-      fields[:fDatime],
-      fields[:fKeylen],
-      fields[:fCycle],
-      fields[:fSeekKey],
-      fields[:fSeekPdir],
-      fields[:fClassName],
-      fields[:fName],
-      fields[:fTitle],
-      fields[:fBufferSize],
-      fields[:fNevBufSize],
-      fields[:fNevBuf],
-      fields[:fLast],
+      fNbytes,
+      fVersion,
+      fObjlen,
+      fDatime,
+      fKeylen,
+      fCycle,
+      fSeekKey,
+      fSeekPdir,
+      fClassName,
+      fName,
+      fTitle,
+      fBufferSize,
+      fNevBufSize,
+      fNevBuf,
+      fLast,
    )
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -60,6 +60,8 @@ end
 function unpack(io, T::Type{TBasketKey})
     start = position(io)
     fields = Dict{Symbol, Union{Integer, String}}()
+    sizehint!(fields, length(fieldnames(T)))
+
     fields[:fNbytes] = readtype(io, Int32)
     fields[:fVersion] = readtype(io, Int16)  # FIXME if "complete" it's UInt16 (acc. uproot)
 
@@ -83,7 +85,23 @@ function unpack(io, T::Type{TBasketKey})
     fields[:fNevBuf] = readtype(io, Int32)
     fields[:fLast] = readtype(io, Int32)
 
-    T(; fields...)
+    T(
+      fields[:fNbytes],
+      fields[:fVersion],
+      fields[:fObjlen],
+      fields[:fDatime],
+      fields[:fKeylen],
+      fields[:fCycle],
+      fields[:fSeekKey],
+      fields[:fSeekPdir],
+      fields[:fClassName],
+      fields[:fName],
+      fields[:fTitle],
+      fields[:fBufferSize],
+      fields[:fNevBufSize],
+      fields[:fNevBuf],
+      fields[:fLast],
+   )
 end
 
 iscompressed(t::T) where T<:Union{TKey, TBasketKey} = t.fObjlen != t.fNbytes - t.fKeylen

--- a/src/types.jl
+++ b/src/types.jl
@@ -68,6 +68,12 @@ function unpack(io, T::Type{TBasketKey})
     fObjlen = readtype(io, Int32)
     fDatime = readtype(io, UInt32)
     fKeylen = readtype(io, Int16)
+
+    # do a single read to get rest of bytes into memory
+    # and offset by the 16 bytes we already read
+    io = IOBuffer(read(io, fKeylen - 16))
+    start = -16
+
     fCycle = readtype(io, Int16)
     fSeekKey = readtype(io, inttype)
     fSeekPdir = readtype(io, inttype)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -60,6 +60,7 @@ function JaggType(f, branch, leaf)
     # https://github.com/scikit-hep/uproot3/blob/54f5151fb7c686c3a161fbe44b9f299e482f346b/uproot3/interp/auto.py#L144
     (match(r"\[.*\]", leaf.fTitle) !== nothing) && return Nooffsetjagg
     leaf isa TLeafElement && leaf.fLenType==0 && return Offsetjagg
+    !hasproperty(branch, :fClassName) && return Nojagg
 
     try
         streamer = streamerfor(f, branch.fClassName).streamer.fElements.elements[1]


### PR DESCRIPTION
When reading files where the performance is not dominated by interpretation, ~20% of the time is in the `fields...` unpacking. In this file, there are ~175 events per basket, probably because there are many branches.
```julia
julia> t.pass_dxysig
57667-element LazyBranch{Bool, UnROOT.Nojagg, Vector{Bool}}:
 0
 ⋮

julia> UnROOT.numbaskets(t.pass_dxysig.b)
328
```
After fixing the 20% `fields...` unpacking time, 75% of the remaining time is spent in `auto_T_JaggT`. See lower in this thread for the explanation.

**before**
```julia
julia> @benchmark sum(t.pass_dxysig)
BenchmarkTools.Trial: 83 samples with 1 evaluation.
 Range (min … max):  57.313 ms … 70.517 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     60.262 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   60.802 ms ±  2.639 ms  ┊ GC (mean ± σ):  0.40% ± 1.66%

 Memory estimate: 2.59 MiB, allocs estimate: 27864.
```

**after**
```julia
julia> @benchmark sum(t.pass_dxysig)
BenchmarkTools.Trial: 378 samples with 1 evaluation.
 Range (min … max):  11.502 ms … 20.477 ms  ┊ GC (min … max): 0.00% … 25.99%
 Time  (median):     12.705 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   13.239 ms ±  1.600 ms  ┊ GC (mean ± σ):  1.19% ±  4.54%

 Memory estimate: 1.62 MiB, allocs estimate: 16056.
```

