### PR TITLE
optimize LazyBranch range getindex and return VoV

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -303,9 +303,12 @@ function Base.iterate(tree::T, idx=1) where {T<:LazyTree}
     return LazyEvent(innertable(tree), idx), idx + 1
 end
 
-# TODO this is not terribly slow, but we can get faster implementation still ;)
-function Base.getindex(ba::LazyBranch{T,J,B}, rang::UnitRange) where {T,J,B}
-    return [ba[i] for i in rang]
+function Base.getindex(ba::LazyBranch{T,J,B}, range::UnitRange) where {T,J,B}
+    ib1 = findfirst(x -> x > (first(range) - 1), ba.fEntry) - 1
+    ib2 = findfirst(x -> x > (last(range) - 1), ba.fEntry) - 1
+    offset = ba.fEntry[ib1]
+    range = (first(range)-offset):(last(range)-offset)
+    return vcat([basketarray(ba, i) for i in ib1:ib2]...)[range]
 end
 
 _clusterranges(t::LazyTree) = _clusterranges([getproperty(t,p) for p in propertynames(t)])


### PR DESCRIPTION
Closes https://github.com/tamasgal/UnROOT.jl/issues/113

With this PR, `Base.getindex(ba::LazyBranch{T,J,B}, range::UnitRange)` will read the right baskets, concatenate them, and chop off the edges to avoid the accumulated cost of many individual `getindex`s in `[ba[i] for i in range]` (`master`). And, the return value is now a `VectorOfVectors` if it's a jagged branch.

I'm using a zlib test file. The `40*10^6:43*10^6]` range has 5 baskets, while the `1:10^6` range has 450 baskets. The improvement is more obvious for the first range.

Out of curiosity I tested `append!()` and found it's basically the same as `vcat`.

```julia
julia> using UnROOT ; const tf = LazyTree(ROOTFile("Run2012BC_DoubleMuParked_Muons.root"),"Events");
```

## `master`

```julia
[ba[i] for i in range]
```

```julia
julia> @btime tf.Muon_pt[40*10^6:43*10^6]
  460.809 ms (217 allocations: 403.03 MiB)
3000001-element Vector{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}}:

julia> @btime tf.Muon_pt[1:10^6]
  172.634 ms (18903 allocations: 154.38 MiB)
1000000-element Vector{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}}:
```

## by basket with vcat

```julia
vcat((basketarray(ba, i) for i in ib1:ib2)...)
```

```julia
julia> @btime tf.Muon_pt[40*10^6:43*10^6]
  416.985 ms (3251 allocations: 392.10 MiB)
3000001-element VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}:

julia> @btime tf.Muon_pt[1:10^6]
  158.825 ms (21193 allocations: 152.86 MiB)
1000000-element VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}:
```

## by basket with append

```julia
out = basketarray(ba, ib1)
for ib in (ib1+1):ib2
  append!(out, basketarray(ba, ib))
end
```

```julia
julia> @btime tf.Muon_pt[40*10^6:43*10^6]
  422.956 ms (3236 allocations: 357.87 MiB)
3000001-element VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}:

julia> @btime tf.Muon_pt[1:10^6]
  161.536 ms (20294 allocations: 154.91 MiB)
1000000-element VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}:
```




