### PR TITLE
add interface function

### DIFF
--- a/src/iteration.jl
+++ b/src/iteration.jl
@@ -332,4 +332,5 @@ function _clusterbytes(lbs::AbstractVector{<:LazyBranch}; compressed=false)
     return bytes
 end
 
+Tables.columns(t::LazyTree) = NamedTuple((p, getproperty(t, p)) for p in propertynames(t))
 Tables.partitions(t::LazyTree) = (t[r] for r in _clusterranges(t))


### PR DESCRIPTION
Closes https://github.com/tamasgal/UnROOT.jl/issues/123

Record batch count matches cluster count, so it's using our `Tables.partitions`.

```julia
julia> using UnROOT, Arrow, Tables

julia> f = UnROOT.samplefile("tree_with_clusters.root");

julia> t = LazyTree(f,"t1")
 Row │ b2             b1
     │ Vector{Int32}  Vector{Int32}
─────┼──────────────────────────────
 1   │ [1, 2]         [0, 1]
 2   │ [2, 3]         [1, 2]
# ...

julia> UnROOT._clusterranges(t)
18-element Vector{UnitRange{Int64}}:
 1:144
 145:288
 ⋮

julia> t |> Arrow.write("test.arrow");
```

```python
>>> import awkward1 as ak
>>> import pyarrow
>>> f = pyarrow.open_file("test.arrow")
>>> f.num_record_batches
18
>>> batch = f.get_batch(0)
>>> ak.from_arrow(batch)["b1"]
<Array [[0, 1], [1, 2, ... 143], [143, 144]] type='144 * var * int32'>
```


