### PR TITLE
avoid intermediate array for lz4/zlib

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -132,11 +132,11 @@ function _decompress_zlib!(input_ptr, input_size, output_ptr, output_size)
     # https://github.com/JuliaIO/CodecZlib.jl/blob/a777d8f53aebd223fe7c7399436a5050784d210f/src/libz.jl
     # https://github.com/root-project/root/blob/87a998d48803bc207288d90038e60ff148827664/core/zip/src/RZip.cxx#L392
     zstream = CodecZlib.ZStream()
-    err = CodecZlib.inflate_init!(zstream, CodecZlib.Z_DEFAULT_WINDOWBITS)
     zstream.next_in = input_ptr
     zstream.avail_in = input_size
     zstream.next_out = output_ptr
     zstream.avail_out = output_size
+    CodecZlib.inflate_init!(zstream, CodecZlib.Z_DEFAULT_WINDOWBITS)
     while (err = CodecZlib.inflate!(zstream, CodecZlib.Z_FINISH) != CodecZlib.Z_STREAM_END)
         if (err != CodecZlib.Z_OK)
             CodecZlib.inflate_end!(zstream)

--- a/src/types.jl
+++ b/src/types.jl
@@ -127,6 +127,31 @@ function compressed_datastream(io, tkey)
     return read(io, tkey.fNbytes - tkey.fKeylen)
 end
 
+function _decompress_zlib!(input_ptr, input_size, output_ptr, output_size)
+    # References:
+    # https://github.com/JuliaIO/CodecZlib.jl/blob/a777d8f53aebd223fe7c7399436a5050784d210f/src/libz.jl
+    # https://github.com/root-project/root/blob/87a998d48803bc207288d90038e60ff148827664/core/zip/src/RZip.cxx#L392
+    zstream = CodecZlib.ZStream()
+    err = CodecZlib.inflate_init!(zstream, CodecZlib.Z_DEFAULT_WINDOWBITS)
+    zstream.next_in = input_ptr
+    zstream.avail_in = input_size
+    zstream.next_out = output_ptr
+    zstream.avail_out = output_size
+    while (err = CodecZlib.inflate!(zstream, CodecZlib.Z_FINISH) != CodecZlib.Z_STREAM_END)
+        if (err != CodecZlib.Z_OK)
+            CodecZlib.inflate_end!(zstream)
+            error(CodecZlib.zlib_error_message(zstream, err))
+        end
+    end
+    CodecZlib.inflate_end!(zstream)
+    nothing
+end
+
+function _decompress_lz4!(input_ptr, input_size, output_ptr, output_size)
+    CodecLz4.LZ4_decompress_safe(input_ptr, output_ptr, input_size, output_size)
+    nothing
+end
+
 """
     decompress_datastreambytes(compbytes, tkey)
 
@@ -148,20 +173,27 @@ function decompress_datastreambytes(compbytes, tkey)
         rawbytes = read(io, compbytes)
 
         if cname == "L4"
-            outptr = pointer(uncomp_data) + fufilled
             # skip checksum which is 8 bytes
+            # original: lz4_decompress(rawbytes[9:end], uncompbytes)
             input = @view rawbytes[9:end]
-            CodecLz4.LZ4_decompress_safe(pointer(input), outptr, length(input), uncompbytes)
+            input_ptr = pointer(input)
+            input_size = length(input)
+            output_ptr = pointer(uncomp_data) + fufilled
+            output_size = uncompbytes
+            _decompress_lz4!(input_ptr, input_size, output_ptr, output_size)
+        elseif cname == "ZL"
+            # original: @view(uncomp_data[fufilled+1:fufilled+uncompbytes]) .= transcode(ZlibDecompressor, rawbytes)
+            input_ptr = pointer(rawbytes)
+            input_size = length(rawbytes)
+            output_ptr = pointer(uncomp_data) + fufilled
+            output_size = uncompbytes
+            _decompress_zlib!(input_ptr, input_size, output_ptr, output_size)
+        elseif cname == "XZ"
+            @view(uncomp_data[fufilled+1:fufilled+uncompbytes]) .= transcode(XzDecompressor, rawbytes)
+        elseif cname == "ZS"
+            @view(uncomp_data[fufilled+1:fufilled+uncompbytes]) .= transcode(ZstdDecompressor, rawbytes)
         else
-            # indexing `0+1 to 0+2` are two bytes, no need to +1 in the second term
-            @view(uncomp_data[fufilled+1:fufilled+uncompbytes]) .= if cname == "ZL"
-                transcode(ZlibDecompressor, rawbytes)
-            elseif cname == "XZ"
-                transcode(XzDecompressor, rawbytes)
-            elseif cname == "ZS"
-                transcode(ZstdDecompressor, rawbytes)
-                error("Unsupported compression type '$(String(compression_header.algo))'")
-            end
+            error("Unsupported compression type '$(String(compression_header.algo))'")
         end
 
         fufilled += uncompbytes


### PR DESCRIPTION
When decompressing, we do something like

`@view(uncomp_data[fufilled+1:fufilled+uncompbytes]) = <output of decompression algo>`

for LZ4, this is actually making a temporary array `out_buffer` which is then copied into `uncomp_data`.

```julia
function lz4_decompress(
        input::Union{Vector{UInt8},Base.CodeUnits{UInt8}},
        expected_size::Integer=length(input) * 2
    )
    out_buffer = Vector{UInt8}(undef, expected_size)
    out_size = LZ4_decompress_safe(pointer(input), pointer(out_buffer), length(input), expected_size)
    resize!(out_buffer, out_size)
end
```

By feeding `LZ4_decompress_safe` a pointer to `uncomp_data`, we can go faster! :rocket: 
And the same exercise was repeated for ZLIB to eliminate the intermediate storage. I copied almost exactly what ROOT has.

## LZ4

#### before

```julia
julia> @btime sum(tf.nMuon)
  600.881 ms (2650 allocations: 870.01 MiB)
0x0000000008e67ad8
```

#### after

```julia
julia> @btime sum(tf.nMuon)
  472.534 ms (2339 allocations: 580.06 MiB)
0x0000000008e67ad8
```


## ZLIB

#### before

```julia
julia> @btime sum(tf.nMuon)
  1.326 s (15170 allocations: 848.43 MiB)
0x0000000008e67ad8


julia> @time sum.(tf.Muon_pt)
  8.802347 seconds (22.05 k allocations: 4.399 GiB, 6.27% gc time)
```

#### after

```julia
julia> @btime sum(tf.nMuon)
  1.107 s (12162 allocations: 544.53 MiB)
0x0000000008e67ad8

julia> @time sum.(tf.Muon_pt)
  7.474018 seconds (18.92 k allocations: 3.216 GiB, 5.11% gc time)

```

......so ~15% speedups for zlib and more for lz4.

