### PR TITLE
fix stacktrace too long

### DIFF
--- a/src/UnROOT.jl
+++ b/src/UnROOT.jl
@@ -17,6 +17,7 @@ import LibDeflate: zlib_decompress!, Decompressor
 import Tables, TypedTables, PrettyTables
 
 @static if VERSION < v"1.6"
+    Base.first(itr, n::Integer) = collect(Iterators.take(itr, n))
     Base.first(a::AbstractVector{S}, n::Integer) where S<: AbstractString = a[1:(length(a) > n ? n : end)]
     Base.first(a::S, n::Integer) where S<: AbstractString = a[1:(length(a) > n ? n : end)]
 end

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -77,6 +77,15 @@ function _show(io::IO, tree::LazyTree; kwargs...)
     )
     nothing
 end
+
+# stop crazy stracktrace
+function Base.show(io::IO, 
+    ::Type{<:LazyTree{<:UnROOT.TypedTables.Table{NamedTuple{Ns, Vs}}}})
+    where {T, Ns, Vs}
+    println(io, "LazyTree with $(length(Ns)) branches:")
+    println(io, collect(Ns))
+end
+
 function Base.show(io::IO, ::MIME"text/html", tree::LazyTree)
     _hs = _make_header(tree)
     maxrows = 10

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -80,8 +80,7 @@ end
 
 # stop crazy stracktrace
 function Base.show(io::IO, 
-    ::Type{<:LazyTree{<:UnROOT.TypedTables.Table{NamedTuple{Ns, Vs}}}})
-    where {T, Ns, Vs}
+    ::Type{<:LazyTree{<:UnROOT.TypedTables.Table{NamedTuple{Ns, Vs}}}}) where {T, Ns, Vs}
     elip = length(Ns) > 5 ? "..." : ""
     println(io, "LazyTree with $(length(Ns)) branches:")
     println(io, join(first(Ns, 5), ", "), elip)

--- a/src/displays.jl
+++ b/src/displays.jl
@@ -82,8 +82,9 @@ end
 function Base.show(io::IO, 
     ::Type{<:LazyTree{<:UnROOT.TypedTables.Table{NamedTuple{Ns, Vs}}}})
     where {T, Ns, Vs}
+    elip = length(Ns) > 5 ? "..." : ""
     println(io, "LazyTree with $(length(Ns)) branches:")
-    println(io, collect(Ns))
+    println(io, join(first(Ns, 5), ", "), elip)
 end
 
 function Base.show(io::IO, ::MIME"text/html", tree::LazyTree)


### PR DESCRIPTION
before:
```julia
arRad, :v_m_tlv, :v_e_topoetcone20, :MET, :v_m_passIso_PflowTight_VarRad_fsr, :w_sf_jvt, :v_m_pid_fsr, :v_j_wgt_btag77, :tauEvent, :v_m_passIso_Loose_FixedRad, :mu, :v_truth_l_tlv, :v_m_topoetcone20, :v_m_passIso_TightTrackOnly_FixedRad_fsr, :v_m_ptcone20_TightTTVA_pt1000, :v_j_btag70, :v_m_d0_fsr, :v_m_tight_fsr, :v_j_tlv, :passTrig, :v_m_ptvarcone30_TightTTVA_pt1000, :v_m_topoetcone20_fsr, :w_prw, :v_e_LHMedium, :v_e_fwd, :v_j_wgt_btag85, :v_m_passIso_Tight_FixedRad_fsr, :v_m_passIso_PflowTight_FixedRad, :v_e_passIso_Loose_VarRad, :v_m_lowpt_fsr, :v_j_btag77, :v_m_ptcone20_TightTTVA_pt1000_fsr, :v_m_passIso_PflowTight_VarRad, :run, :v_m_lowpt, :v_m_passIso_TightTrackOnly_FixedRad, :v_m_medium_fsr, :v_e_pid, :v_j_wgt_btagCont, :v_m_wgtIso, :v_m_ptvarcone30_TightTTVA_pt500, :v_m_passIso_HighPtTrackOnly_fsr, :v_truth_l_fromTau, :v_m_passIso_PflowLoose_FixedRad, :v_m_passIso_Tight_FixedRad, :v_m_wgtIso_fsr, :v_m_passIso_Loose_VarRad, :v_m_ptcone20_TightTTVA_pt500_fsr, :v_m_passIso_PflowLoose_VarRad_fsr, :v_e_ptcone20_TightTTVALooseCone_pt1000, :v_e_ambiguous, :event, :METSig, :v_j_wgt_btag70, :v_e_LHTight, :v_m_CtSaSa, :v_m_passIso_TightTrackOnly_VarRad_fsr, :v_m_wgtIsoVarRad_fsr, :METPhi, :v_m_wgtLoose_fsr, :v_m_ptvarcone30_TightTTVA_pt1000_fsr, :v_truth_j_tlv, :v_m_passIso_HighPtTrackOnly, :v_m_tight, :v_m_passIso_PflowTight_FixedRad_fsr, :v_m_tlv_fsr, :v_e_wgtTight, :v_m_medium, :v_truth_l_pdgId, :v_e_wgtLoose, :v_e_ptvarcone30_TightTTVALooseCone_pt1000, :v_e_passIso_HighPtCaloOnly, :v_e_wgtIso, :v_mcGenWgt, :weight, :v_m_CtSaSa_fsr, :v_m_ptcone20_TightTTVA_pt500, :v_m_wgtLoose, :v_m_neflowisol20_fsr, :v_m_passIso_PflowLoose_VarRad, :v_e_tlv, :v_m_passIso_Tight_VarRad, :v_j_btag85, :v_m_passIso_Loose_FixedRad_fsr, :v_e_passIso_TightTrackOnly_VarRad, :v_m_neflowisol20, :v_m_pid, :v_j_wgt_btag60, :v_m_ptvarcone30_TightTTVA_pt500_fsr, :v_m_wgtIsoVarRad, :v_e_passIso_TightTrackOnly_FixedRad, :v_m_passIso_PflowLoose_FixedRad_fsr, :v_m_d0, :v_j_btag60, :v_j_btagCont, :v_m_passIso_Loose_VarRad_fsr, :v_m_passIso_TightTrackOnly_VarRad, :v_m_passIso_Tight_VarRad_fsr), Tuple{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, Float64, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, Float32, SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, Bool, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, Float32, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, Bool, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, Float32, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, Int32, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UInt64, Float64, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, Float64, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, Float64, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}}}, 1, NamedTuple{(:v_e_passIso_Tight_VarRad, :v_m_tlv, :v_e_topoetcone20, :MET, :v_m_passIso_PflowTight_VarRad_fsr, :w_sf_jvt, :v_m_pid_fsr, :v_j_wgt_btag77, :tauEvent, :v_m_passIso_Loose_FixedRad, :mu, :v_truth_l_tlv, :v_m_topoetcone20, :v_m_passIso_TightTrackOnly_FixedRad_fsr, :v_m_ptcone20_TightTTVA_pt1000, :v_j_btag70, :v_m_d0_fsr, :v_m_tight_fsr, :v_j_tlv, :passTrig, :v_m_ptvarcone30_TightTTVA_pt1000, :v_m_topoetcone20_fsr, :w_prw, :v_e_LHMedium, :v_e_fwd, :v_j_wgt_btag85, :v_m_passIso_Tight_FixedRad_fsr, :v_m_passIso_PflowTight_FixedRad, :v_e_passIso_Loose_VarRad, :v_m_lowpt_fsr, :v_j_btag77, :v_m_ptcone20_TightTTVA_pt1000_fsr, :v_m_passIso_PflowTight_VarRad, :run, :v_m_lowpt, :v_m_passIso_TightTrackOnly_FixedRad, :v_m_medium_fsr, :v_e_pid, :v_j_wgt_btagCont, :v_m_wgtIso, :v_m_ptvarcone30_TightTTVA_pt500, :v_m_passIso_HighPtTrackOnly_fsr, :v_truth_l_fromTau, :v_m_passIso_PflowLoose_FixedRad, :v_m_passIso_Tight_FixedRad, :v_m_wgtIso_fsr, :v_m_passIso_Loose_VarRad, :v_m_ptcone20_TightTTVA_pt500_fsr, :v_m_passIso_PflowLoose_VarRad_fsr, :v_e_ptcone20_TightTTVALooseCone_pt1000, :v_e_ambiguous, :event, :METSig, :v_j_wgt_btag70, :v_e_LHTight, :v_m_CtSaSa, :v_m_passIso_TightTrackOnly_VarRad_fsr, :v_m_wgtIsoVarRad_fsr, :METPhi, :v_m_wgtLoose_fsr, :v_m_ptvarcone30_TightTTVA_pt1000_fsr, :v_truth_j_tlv, :v_m_passIso_HighPtTrackOnly, :v_m_tight, :v_m_passIso_PflowTight_FixedRad_fsr, :v_m_tlv_fsr, :v_e_wgtTight, :v_m_medium, :v_truth_l_pdgId, :v_e_wgtLoose, :v_e_ptvarcone30_TightTTVALooseCone_pt1000, :v_e_passIso_HighPtCaloOnly, :v_e_wgtIso, :v_mcGenWgt, :weight, :v_m_CtSaSa_fsr, :v_m_ptcone20_TightTTVA_pt500, :v_m_wgtLoose, :v_m_neflowisol20_fsr, :v_m_passIso_PflowLoose_VarRad, :v_e_tlv, :v_m_passIso_Tight_VarRad, :v_j_btag85, :v_m_passIso_Loose_FixedRad_fsr, :v_e_passIso_TightTrackOnly_VarRad, :v_m_neflowisol20, :v_m_pid, :v_j_wgt_btag60, :v_m_ptvarcone30_TightTTVA_pt500_fsr, :v_m_wgtIsoVarRad, :v_e_passIso_TightTrackOnly_FixedRad, :v_m_passIso_PflowLoose_FixedRad_fsr, :v_m_d0, :v_j_btag60, :v_j_btagCont, :v_m_passIso_Loose_VarRad_fsr, :v_m_passIso_TightTrackOnly_VarRad, :v_m_passIso_Tight_VarRad_fsr), Tuple{LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float64, UnROOT.Nojagg, Vector{Float64}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float32, UnROOT.Nojagg, Vector{Float32}}, LazyBranch{SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Int32, Vector{Int32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Bool, UnROOT.Nojagg, Vector{Bool}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float32, UnROOT.Nojagg, Vector{Float32}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Bool, UnROOT.Nojagg, Vector{Bool}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float32, UnROOT.Nojagg, Vector{Float32}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Int32, UnROOT.Nojagg, Vector{Int32}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Int32, Vector{Int32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{UInt64, UnROOT.Nojagg, Vector{UInt64}}, LazyBranch{Float64, UnROOT.Nojagg, Vector{Float64}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float64, UnROOT.Nojagg, Vector{Float64}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Int32, Vector{Int32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{Float64, UnROOT.Nojagg, Vector{Float64}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{LorentzVectors.LorentzVector{Float64}, 1, Vector{LorentzVectors.LorentzVector{Float64}}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{LorentzVectors.LorentzVector{Float64}, Vector{LorentzVectors.LorentzVector{Float64}}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Int32, Vector{Int32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Float32, 1, Vector{Float32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Float32, Vector{Float32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Int32, 1, Vector{Int32}, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Int32, Vector{Int32}, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}, LazyBranch{SubArray{Bool, 1, BitVector, Tuple{UnitRange{Int64}}, true}, UnROOT.Offsetjagg, ArraysOfArrays.VectorOfVectors{Bool, BitVector, Vector{Int32}, Vector{Tuple{}}}}}}}}})
```

after:
```julia
julia> tree[1:3, !]
ERROR: ArgumentError: invalid index: ! of type typeof(!)
Stacktrace:
 [1] to_index(i::Function)
   @ Base ./indices.jl:300
 [2] to_index(A::LazyTree with 98 branches:
v_e_passIso_Tight_VarRad, v_m_tlv, v_e_topoetcone20, MET, v_m_passIso_PflowTight_VarRad_fsr...
, i::Function)
   @ Base ./indices.jl:277
 [3] to_indices(A::LazyTree with 98 branches:
v_e_passIso_Tight_VarRad, v_m_tlv, v_e_topoetcone20, MET, v_m_passIso_PflowTight_VarRad_fsr...
, inds::Tuple{}, I::Tuple{typeof(!)}) (repeats 2 times)
   @ Base ./indices.jl:333
 [4] to_indices
   @ ./indices.jl:324 [inlined]
 [5] getindex(::LazyTree with 98 branches:
v_e_passIso_Tight_VarRad, v_m_tlv, v_e_topoetcone20, MET, v_m_passIso_PflowTight_VarRad_fsr...
, ::UnitRange{Int64}, ::Function)
   @ Base ./abstractarray.jl:1218
 [6] top-level scope
   @ REPL[52]:1
```